### PR TITLE
Add redirect URL, and set page title

### DIFF
--- a/app/src/app/(pages)/components/Sidebar.tsx
+++ b/app/src/app/(pages)/components/Sidebar.tsx
@@ -7,8 +7,8 @@ import { Fragment, useEffect, useState } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { useQuery } from "@tanstack/react-query";
 import {
-  LOGIN_URL,
   getJwt,
+  getLoginUrl,
   getSubscriptionBalance,
   removeJwt,
 } from "@/app/_lib/api";
@@ -72,7 +72,7 @@ function SidebarContent() {
 
   const signOut = () => {
     removeJwt();
-    redirect(LOGIN_URL);
+    redirect(getLoginUrl());
   };
 
   return (

--- a/app/src/app/(pages)/devices/components/ShareDeviceDialog.tsx
+++ b/app/src/app/(pages)/devices/components/ShareDeviceDialog.tsx
@@ -45,10 +45,6 @@ export default function ShareDeviceDialog({
     mutateDeviceCreateShareCode();
   }, []);
 
-  const encodeURI = (text: string) => {
-    return text.replaceAll(" ", "+");
-  };
-
   return (
     <Dialog
       open={isOpen}
@@ -93,7 +89,7 @@ export default function ShareDeviceDialog({
                 <div className="text-sm text-center border border-gray-400 rounded-md p-2">
                   <p className="text-clip whitespace-pre-wrap">
                     https://app.bringyour.com/devices/add?code=
-                    {encodeURI(shareCodeResult.share_code)}
+                    {shareCodeResult.share_code.replaceAll(" ", "+")}
                   </p>
                 </div>
                 <div>

--- a/app/src/app/_lib/api.ts
+++ b/app/src/app/_lib/api.ts
@@ -26,6 +26,15 @@ import {
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.bringyour.com/";
 export const LOGIN_URL = "https://bringyour.com?auth";
 
+export function getLoginUrl() {
+  if (!window || !window.location) {
+    return LOGIN_URL;
+  }
+
+  const encodedRedirectUri = encodeURI(window.location.href);
+  return `${LOGIN_URL}&redirect-uri-after-auth=${encodedRedirectUri}`;
+}
+
 export function getJwt() {
   if (typeof localStorage == "undefined") {
     return null;

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -3,7 +3,7 @@
 import "./globals.css";
 import { redirect, usePathname, useSearchParams } from "next/navigation";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { LOGIN_URL, getJwt, postAuthCodeLogin, removeJwt } from "@lib/api";
+import { getJwt, getLoginUrl, postAuthCodeLogin, removeJwt } from "@lib/api";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 
@@ -31,7 +31,7 @@ export default function RootLayout({
      */
     if (!authParam && !isLoggedIn) {
       // User needs to log in
-      redirect(LOGIN_URL);
+      redirect(getLoginUrl());
     }
 
     if (!authParam && isLoggedIn && pathname == "/") {
@@ -49,7 +49,7 @@ export default function RootLayout({
       } catch (e: any) {
         alert("Failed to log in. Please try again.");
         removeJwt();
-        router.push(LOGIN_URL);
+        router.push(getLoginUrl());
       }
     }
     handleAuthParam(authParam);


### PR DESCRIPTION
This PR implements:
1. Set the page title to "BringYour: Manage Your Network" for all pages (https://github.com/bringyour/web/issues/32)
2. Add a favicon to each page (using the same favicon as bringyour.com).
3. Add a `redirect-uri-after-auth` param to all login request (https://github.com/bringyour/web/issues/27).
    a. The code uses the [encodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) javascript function to encode the redirect URI.